### PR TITLE
MRG: Switch to Numpy docstring format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,8 +32,10 @@ master_doc = 'index'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.autosummary']
-
+extensions = ['sphinx.ext.autodoc',
+              'sphinx.ext.viewcode',
+              'sphinx.ext.autosummary',
+              'sphinx.ext.napoleon']
 
 # Config autosummary
 autosummary_generate = True


### PR DESCRIPTION
Convert to Numpy format docstrings.

Use standard Sphinx Napoleon extension to parse docstrings for built docs.

As well as the docstring changes, some functions need to have
parameters specified as keyword only in order to be drop-in compatible
with Pandas.  Can I check with you, that you agree?  Obviously this makes
the code Python 3 only, but doesn't seem like a problem at this point.