### PR TITLE
MRG: convert tabs to spaces in tests

### DIFF
--- a/tests/test_df.py
+++ b/tests/test_df.py
@@ -12,197 +12,197 @@ import pandas as pd
 
 @pytest.fixture(scope='function')
 def dfs():
-	inputs = []
-	# df1 input: Strings and numbers DataFrame
-	inputs.append({'data': {'letter': ['a', 'b', 'c'], 
-						    'count': [9,3,3], 
-						    'idx': [0,1,2]}})
-	# df2 input: All numbers DataFrame
-	inputs.append({'data': {'col1': [5, 2, 7, 5], 
-						    'col2': [2, 7, 1, 8], 
-						    'col3': [6, 6, 1, 3], 
-						    'col4': [5, 5, 5, 9]}})
-	# df3 input: DataFrame with groups
-	inputs.append({'data': {'name': ['dog', 'cat', 'pidgeon', 'chicken', 'snake'], 
-						    'kind': ['mammal', 'mammal', 'bird', 'bird', 'reptile']}})
-	# df4 input: DataFrame for merge
-	inputs.append({'data': {'kind': ['mammal', 'bird', 'reptile'], 
-						    'short': ['m',  'b', 'r']}})
-	# df5 input: DataFrame for append
-	inputs.append({'data': {'letter': ['d' ,'e'],
-					  	    'count': [4, 1],
-						    'idx': [3, 4]}})
+    inputs = []
+    # df1 input: Strings and numbers DataFrame
+    inputs.append({'data': {'letter': ['a', 'b', 'c'],
+                            'count': [9,3,3],
+                            'idx': [0,1,2]}})
+    # df2 input: All numbers DataFrame
+    inputs.append({'data': {'col1': [5, 2, 7, 5],
+                            'col2': [2, 7, 1, 8],
+                            'col3': [6, 6, 1, 3],
+                            'col4': [5, 5, 5, 9]}})
+    # df3 input: DataFrame with groups
+    inputs.append({'data': {'name': ['dog', 'cat', 'pidgeon', 'chicken', 'snake'],
+                            'kind': ['mammal', 'mammal', 'bird', 'bird', 'reptile']}})
+    # df4 input: DataFrame for merge
+    inputs.append({'data': {'kind': ['mammal', 'bird', 'reptile'],
+                            'short': ['m',  'b', 'r']}})
+    # df5 input: DataFrame for append
+    inputs.append({'data': {'letter': ['d' ,'e'],
+                            'count': [4, 1],
+                            'idx': [3, 4]}})
 
-	dct = {}
-	for key in range(len(inputs)):
-		dct['df{}'.format(key + 1)] = (bpd.DataFrame(**inputs[key]), pd.DataFrame(**inputs[key]))
-	return dct
+    dct = {}
+    for key in range(len(inputs)):
+        dct['df{}'.format(key + 1)] = (bpd.DataFrame(**inputs[key]), pd.DataFrame(**inputs[key]))
+    return dct
 
 def assert_df_equal(df, pdf, method=None, **kwargs):
-	if method:
-		df = getattr(df, method)(**kwargs)
-		pdf = getattr(pdf, method)(**kwargs)
+    if method:
+        df = getattr(df, method)(**kwargs)
+        pdf = getattr(pdf, method)(**kwargs)
 
-	assert (np.all(df.columns == pdf.columns)), 'Columns do not match'
-	assert (np.all(df.index == pdf.index)), 'Indices do not match'
-	assert (np.all(df.values == pdf.values)), 'Values do not match'
+    assert (np.all(df.columns == pdf.columns)), 'Columns do not match'
+    assert (np.all(df.index == pdf.index)), 'Indices do not match'
+    assert (np.all(df.values == pdf.values)), 'Values do not match'
 
 def assert_series_equal(ser, pser, method=None, **kwargs):
-	if method:
-		ser = getattr(ser, method)(**kwargs)
-		pser = getattr(pser, method)(**kwargs)
+    if method:
+        ser = getattr(ser, method)(**kwargs)
+        pser = getattr(pser, method)(**kwargs)
 
-	assert (np.all(ser.index == pser.index)), 'Indices do not match'
-	assert (np.all(ser.values == pser.values)), 'Values do not match'
+    assert (np.all(ser.index == pser.index)), 'Indices do not match'
+    assert (np.all(ser.values == pser.values)), 'Values do not match'
 
 #########
 # Tests #
 #########
 
 def test_basic(dfs):
-	for df, pdf in dfs.values():
-		assert_df_equal(df, pdf)
+    for df, pdf in dfs.values():
+        assert_df_equal(df, pdf)
 
 def test_iloc(dfs):
-	for df, pdf in dfs.values():
-		assert_series_equal(df.iloc[0], pdf.iloc[0])
+    for df, pdf in dfs.values():
+        assert_series_equal(df.iloc[0], pdf.iloc[0])
 
 def test_take(dfs):
-	for df, pdf in dfs.values():
-		indices = np.random.choice(len(pdf), 2, replace=False)
-		assert_df_equal(df, pdf, 'take', indices=indices)
+    for df, pdf in dfs.values():
+        indices = np.random.choice(len(pdf), 2, replace=False)
+        assert_df_equal(df, pdf, 'take', indices=indices)
 
-	# Exceptions
-	df1 = dfs['df1'][0]
-	assert pytest.raises(TypeError, df1.take, indices=1)
-	assert pytest.raises(ValueError, df1.take, indices=['foo'])
-	assert pytest.raises(IndexError, df1.take, indices=np.arange(4))
+    # Exceptions
+    df1 = dfs['df1'][0]
+    assert pytest.raises(TypeError, df1.take, indices=1)
+    assert pytest.raises(ValueError, df1.take, indices=['foo'])
+    assert pytest.raises(IndexError, df1.take, indices=np.arange(4))
 
 def test_drop(dfs):
-	for df, pdf in dfs.values():
-		col = pdf.columns.to_series().sample()
-		assert_df_equal(df, pdf, 'drop', columns=col)
+    for df, pdf in dfs.values():
+        col = pdf.columns.to_series().sample()
+        assert_df_equal(df, pdf, 'drop', columns=col)
 
-	# Exceptions
-	df1 = dfs['df1'][0]
-	assert pytest.raises(TypeError, df1.drop, columns=0)
-	assert pytest.raises(KeyError, df1.drop, columns=['count', 'foo'])
+    # Exceptions
+    df1 = dfs['df1'][0]
+    assert pytest.raises(TypeError, df1.drop, columns=0)
+    assert pytest.raises(KeyError, df1.drop, columns=['count', 'foo'])
 
 def test_sample(dfs):
-	for df, pdf in dfs.values():
-		assert_df_equal(df, pdf, 'sample', n=1, random_state=0)
-		assert_df_equal(df, pdf, 'sample', n=2, random_state=50)
+    for df, pdf in dfs.values():
+        assert_df_equal(df, pdf, 'sample', n=1, random_state=0)
+        assert_df_equal(df, pdf, 'sample', n=2, random_state=50)
 
-	# Exceptions
-	df1 = dfs['df1'][0]
-	assert pytest.raises(TypeError, df1.sample, n='foo')
-	assert pytest.raises(TypeError, df1.sample, replace='foo')
-	assert pytest.raises(TypeError, df1.sample, random_state='foo')
-	assert pytest.raises(ValueError, df1.sample, n=8)
+    # Exceptions
+    df1 = dfs['df1'][0]
+    assert pytest.raises(TypeError, df1.sample, n='foo')
+    assert pytest.raises(TypeError, df1.sample, replace='foo')
+    assert pytest.raises(TypeError, df1.sample, random_state='foo')
+    assert pytest.raises(ValueError, df1.sample, n=8)
 
 def test_get(dfs):
-	for df, pdf in dfs.values():
-		key = pdf.columns.to_series().sample(2).values
-		assert_series_equal(df, pdf, 'get', key=key[0])
-		assert_df_equal(df, pdf, 'get', key=key)
+    for df, pdf in dfs.values():
+        key = pdf.columns.to_series().sample(2).values
+        assert_series_equal(df, pdf, 'get', key=key[0])
+        assert_df_equal(df, pdf, 'get', key=key)
 
-	# Exceptions
-	df1 = dfs['df1'][0]
-	assert pytest.raises(TypeError, df1.get, key=1)
-	assert pytest.raises(KeyError, df1.get, key='foo')
+    # Exceptions
+    df1 = dfs['df1'][0]
+    assert pytest.raises(TypeError, df1.get, key=1)
+    assert pytest.raises(KeyError, df1.get, key='foo')
 
 def test_assign(dfs):
-	df2, pdf2 = dfs['df2']
-	assert_df_equal(df2, pdf2, 'assign', col5=[1, 1, 1, 1])
+    df2, pdf2 = dfs['df2']
+    assert_df_equal(df2, pdf2, 'assign', col5=[1, 1, 1, 1])
 
-	# Exceptions
-	assert pytest.raises(ValueError, df2.assign, col5=[1, 1, 1, 1], col6=[2, 2])
-	assert pytest.raises(ValueError, df2.assign, col5=[1, 1])
+    # Exceptions
+    assert pytest.raises(ValueError, df2.assign, col5=[1, 1, 1, 1], col6=[2, 2])
+    assert pytest.raises(ValueError, df2.assign, col5=[1, 1])
 
 def test_apply(dfs):
-	df2, pdf2 = dfs['df2']
-	f = lambda x: x + 2
-	assert_df_equal(df2, pdf2, 'apply', func=f)
+    df2, pdf2 = dfs['df2']
+    f = lambda x: x + 2
+    assert_df_equal(df2, pdf2, 'apply', func=f)
 
-	# Exceptions
-	assert pytest.raises(TypeError, df2.apply, func=2)
-	assert pytest.raises(ValueError, df2.apply, func=f, axis=3)
+    # Exceptions
+    assert pytest.raises(TypeError, df2.apply, func=2)
+    assert pytest.raises(ValueError, df2.apply, func=f, axis=3)
 
 def test_sort_values(dfs):
-	for df, pdf in dfs.values():
-		by = pdf.columns.to_series().sample().iloc[0]
-		assert_df_equal(df, pdf, by=by)
-		assert_df_equal(df, pdf, by=by, ascending=False)
+    for df, pdf in dfs.values():
+        by = pdf.columns.to_series().sample().iloc[0]
+        assert_df_equal(df, pdf, by=by)
+        assert_df_equal(df, pdf, by=by, ascending=False)
 
-	# Exceptions
-	df1 = dfs['df1'][0]
-	assert pytest.raises(TypeError, df1.sort_values, by=0)
-	assert pytest.raises(KeyError, df1.sort_values, by='foo')
-	assert pytest.raises(TypeError, df1.sort_values, by='count', ascending='foo')
+    # Exceptions
+    df1 = dfs['df1'][0]
+    assert pytest.raises(TypeError, df1.sort_values, by=0)
+    assert pytest.raises(KeyError, df1.sort_values, by='foo')
+    assert pytest.raises(TypeError, df1.sort_values, by='count', ascending='foo')
 
 def test_describe(dfs):
-	for df, pdf in dfs.values():
-		assert_df_equal(df, pdf, 'describe')
+    for df, pdf in dfs.values():
+        assert_df_equal(df, pdf, 'describe')
 
 def test_groupby(dfs):
-	df3, pdf3 = dfs['df3']
-	gb = df3.groupby('kind')
-	pgb = pdf3.groupby('kind')
-	assert isinstance(gb, bpd.DataFrameGroupBy)
-	assert_df_equal(gb.sum(), pgb.sum())
+    df3, pdf3 = dfs['df3']
+    gb = df3.groupby('kind')
+    pgb = pdf3.groupby('kind')
+    assert isinstance(gb, bpd.DataFrameGroupBy)
+    assert_df_equal(gb.sum(), pgb.sum())
 
-	# Exceptions
-	assert pytest.raises(TypeError, df3.groupby, by=0)
-	assert pytest.raises(KeyError, df3.groupby, by='foo')
+    # Exceptions
+    assert pytest.raises(TypeError, df3.groupby, by=0)
+    assert pytest.raises(KeyError, df3.groupby, by='foo')
 
 def test_reset_index(dfs):
-	for df, pdf in dfs.values():
-		by = pdf.columns.to_series().sample().iloc[0]
-		df = df.sort_values(by=by)
-		pdf = pdf.sort_values(by=by)
-		assert_df_equal(df, pdf, 'reset_index')
-		assert_df_equal(df, pdf, 'reset_index', drop=True)
+    for df, pdf in dfs.values():
+        by = pdf.columns.to_series().sample().iloc[0]
+        df = df.sort_values(by=by)
+        pdf = pdf.sort_values(by=by)
+        assert_df_equal(df, pdf, 'reset_index')
+        assert_df_equal(df, pdf, 'reset_index', drop=True)
 
-	# Exceptions
-	df2 = dfs['df2'][0]
-	assert pytest.raises(TypeError, df2.reset_index, drop='foo')
+    # Exceptions
+    df2 = dfs['df2'][0]
+    assert pytest.raises(TypeError, df2.reset_index, drop='foo')
 
 def test_set_index(dfs):
-	for df, pdf in dfs.values():
-		keys = pdf.columns.to_series().sample().iloc[0]
-		assert_df_equal(df, pdf, 'set_index', keys=keys)
-		assert_df_equal(df, pdf, 'set_index', keys=keys, drop=False)
+    for df, pdf in dfs.values():
+        keys = pdf.columns.to_series().sample().iloc[0]
+        assert_df_equal(df, pdf, 'set_index', keys=keys)
+        assert_df_equal(df, pdf, 'set_index', keys=keys, drop=False)
 
-	# Exceptions
-	df2 = dfs['df2'][0]
-	assert pytest.raises(TypeError, df2.set_index, keys=0)
-	assert pytest.raises(KeyError, df2.set_index, keys='foo')
-	assert pytest.raises(TypeError, df2.set_index, keys='col1', drop='foo')
+    # Exceptions
+    df2 = dfs['df2'][0]
+    assert pytest.raises(TypeError, df2.set_index, keys=0)
+    assert pytest.raises(KeyError, df2.set_index, keys='foo')
+    assert pytest.raises(TypeError, df2.set_index, keys='col1', drop='foo')
 
 def test_merge(dfs):
-	df3, pdf3 = dfs['df3']
-	df4, pdf4 = dfs['df4']
-	assert_df_equal(df3.merge(df4), pdf3.merge(pdf4))
+    df3, pdf3 = dfs['df3']
+    df4, pdf4 = dfs['df4']
+    assert_df_equal(df3.merge(df4), pdf3.merge(pdf4))
 
-	# Exceptions
-	assert pytest.raises(TypeError, df3.merge, right=np.array([1, 2, 3]))
-	assert pytest.raises(ValueError, df3.merge, right=df4, how='on')
-	assert pytest.raises(KeyError, df3.merge, right=df4, on='foo')
-	assert pytest.raises(KeyError, df3.merge, right=df4, left_on='kind')
-	assert pytest.raises(KeyError, df3.merge, right=df4, left_on='foo', right_on='kind')
-	assert pytest.raises(KeyError, df3.merge, right=df4, left_on='kind', right_on='foo')
+    # Exceptions
+    assert pytest.raises(TypeError, df3.merge, right=np.array([1, 2, 3]))
+    assert pytest.raises(ValueError, df3.merge, right=df4, how='on')
+    assert pytest.raises(KeyError, df3.merge, right=df4, on='foo')
+    assert pytest.raises(KeyError, df3.merge, right=df4, left_on='kind')
+    assert pytest.raises(KeyError, df3.merge, right=df4, left_on='foo', right_on='kind')
+    assert pytest.raises(KeyError, df3.merge, right=df4, left_on='kind', right_on='foo')
 
 def test_append(dfs):
-	df1, pdf1 = dfs['df1']
-	df5, pdf5 = dfs['df5']
-	assert_df_equal(df1.append(df5), pdf1.append(pdf5))
-	assert_df_equal(df1.append(df5, ignore_index=True), pdf1.append(pdf5, ignore_index=True))
-	
-	# Exceptions
-	assert pytest.raises(TypeError, df1.append, right=np.array([1, 2, 3]))
-	assert pytest.raises(TypeError, df1.append, right=df5, ignore_index='foo')
+    df1, pdf1 = dfs['df1']
+    df5, pdf5 = dfs['df5']
+    assert_df_equal(df1.append(df5), pdf1.append(pdf5))
+    assert_df_equal(df1.append(df5, ignore_index=True), pdf1.append(pdf5, ignore_index=True))
+
+    # Exceptions
+    assert pytest.raises(TypeError, df1.append, right=np.array([1, 2, 3]))
+    assert pytest.raises(TypeError, df1.append, right=df5, ignore_index='foo')
 
 def test_to_numpy(dfs):
-	for df, pdf in dfs.values():
-		assert isinstance(df.to_numpy(), np.ndarray)
-		assert_array_equal(df.to_numpy(), pdf.to_numpy())
+    for df, pdf in dfs.values():
+        assert isinstance(df.to_numpy(), np.ndarray)
+        assert_array_equal(df.to_numpy(), pdf.to_numpy())

--- a/tests/test_ser.py
+++ b/tests/test_ser.py
@@ -12,100 +12,100 @@ import pandas as pd
 
 @pytest.fixture(scope='function')
 def sers():
-	inputs = []
-	# ser1 input: Sorted Series
-	inputs.append({'data': [1, 2, 3, 4, 5]})
-	# ser2 input: String Series
-	inputs.append({'data': ['a', 'b', 'c', 'd']})
-	# ser3 input: Unsorted Series
-	inputs.append({'data': [7, 1, 3, 4, 2]})
+    inputs = []
+    # ser1 input: Sorted Series
+    inputs.append({'data': [1, 2, 3, 4, 5]})
+    # ser2 input: String Series
+    inputs.append({'data': ['a', 'b', 'c', 'd']})
+    # ser3 input: Unsorted Series
+    inputs.append({'data': [7, 1, 3, 4, 2]})
 
-	dct = {}
-	for key in range(len(inputs)):
-		dct['ser{}'.format(key + 1)] = (bpd.Series(**inputs[key]), pd.Series(**inputs[key]))
-	return dct
+    dct = {}
+    for key in range(len(inputs)):
+        dct['ser{}'.format(key + 1)] = (bpd.Series(**inputs[key]), pd.Series(**inputs[key]))
+    return dct
 
 def assert_df_equal(df, pdf, method=None, **kwargs):
-	if method:
-		df = getattr(df, method)(**kwargs)
-		pdf = getattr(pdf, method)(**kwargs)
+    if method:
+        df = getattr(df, method)(**kwargs)
+        pdf = getattr(pdf, method)(**kwargs)
 
-	assert (np.all(df.columns == pdf.columns)), 'Columns do not match'
-	assert (np.all(df.index == pdf.index)), 'Indices do not match'
-	assert (np.all(df.values == pdf.values)), 'Values do not match'
+    assert (np.all(df.columns == pdf.columns)), 'Columns do not match'
+    assert (np.all(df.index == pdf.index)), 'Indices do not match'
+    assert (np.all(df.values == pdf.values)), 'Values do not match'
 
 def assert_series_equal(ser, pser, method=None, **kwargs):
-	if method:
-		ser = getattr(ser, method)(**kwargs)
-		pser = getattr(pser, method)(**kwargs)
+    if method:
+        ser = getattr(ser, method)(**kwargs)
+        pser = getattr(pser, method)(**kwargs)
 
-	assert (np.all(ser.index == pser.index)), 'Indices do not match'
-	assert (np.all(ser.values == pser.values)), 'Values do not match'
+    assert (np.all(ser.index == pser.index)), 'Indices do not match'
+    assert (np.all(ser.values == pser.values)), 'Values do not match'
 
 #########
 # Tests #
 #########
 
 def test_basic(sers):
-	for ser, pser in sers.values():
-		assert_series_equal(ser, pser)
+    for ser, pser in sers.values():
+        assert_series_equal(ser, pser)
 
 def test_take(sers):
-	for ser, pser in sers.values():
-		indices = np.random.choice(len(pser), 2, replace=False)
-		assert_series_equal(ser, pser, 'take', indices=indices)
+    for ser, pser in sers.values():
+        indices = np.random.choice(len(pser), 2, replace=False)
+        assert_series_equal(ser, pser, 'take', indices=indices)
 
-	# Exceptions
-	ser1 = sers['ser1'][0]
-	assert pytest.raises(TypeError, ser1.take, indices=0)
-	assert pytest.raises(ValueError, ser1.take, indices=['foo'])
-	assert pytest.raises(IndexError, ser1.take, indices=np.arange(6))
+    # Exceptions
+    ser1 = sers['ser1'][0]
+    assert pytest.raises(TypeError, ser1.take, indices=0)
+    assert pytest.raises(ValueError, ser1.take, indices=['foo'])
+    assert pytest.raises(IndexError, ser1.take, indices=np.arange(6))
 
 def test_sample(sers):
-	for ser, pser in sers.values():
-		assert_series_equal(ser, pser, 'sample', n=3, random_state=0)
-		assert_series_equal(ser, pser, 'sample', n=8, replace=True, random_state=0)
+    for ser, pser in sers.values():
+        assert_series_equal(ser, pser, 'sample', n=3, random_state=0)
+        assert_series_equal(ser, pser, 'sample', n=8, replace=True, random_state=0)
 
-	# Exceptions
-	ser1 = sers['ser1'][0]
-	assert pytest.raises(TypeError, ser1.sample, n='foo')
-	assert pytest.raises(TypeError, ser1.sample, replace='foo')
-	assert pytest.raises(TypeError, ser1.sample, random_state='foo')
-	assert pytest.raises(ValueError, ser1.sample, n=8)
+    # Exceptions
+    ser1 = sers['ser1'][0]
+    assert pytest.raises(TypeError, ser1.sample, n='foo')
+    assert pytest.raises(TypeError, ser1.sample, replace='foo')
+    assert pytest.raises(TypeError, ser1.sample, random_state='foo')
+    assert pytest.raises(ValueError, ser1.sample, n=8)
 
 def test_apply(sers):
-	ser1, pser1 = sers['ser1']
-	f = lambda x: x + 2
-	assert_series_equal(ser1, pser1, 'apply', func=f)
+    ser1, pser1 = sers['ser1']
+    f = lambda x: x + 2
+    assert_series_equal(ser1, pser1, 'apply', func=f)
 
-	# Exceptions
-	assert pytest.raises(TypeError, ser1.apply, func='foo')
+    # Exceptions
+    assert pytest.raises(TypeError, ser1.apply, func='foo')
 
 def test_sort_values(sers):
-	for ser, pser in sers.values():
-		assert_series_equal(ser, pser, 'sort_values')
-		assert_series_equal(ser, pser, 'sort_values', ascending=False)
+    for ser, pser in sers.values():
+        assert_series_equal(ser, pser, 'sort_values')
+        assert_series_equal(ser, pser, 'sort_values', ascending=False)
 
-	# Exceptions
-	ser3 = sers['ser3'][0]
-	assert pytest.raises(TypeError, ser3.sort_values, ascending='foo')
+    # Exceptions
+    ser3 = sers['ser3'][0]
+    assert pytest.raises(TypeError, ser3.sort_values, ascending='foo')
 
 def test_describe(sers):
-	for ser, pser in sers.values():
-		assert_series_equal(ser, pser, 'describe')
+    for ser, pser in sers.values():
+        assert_series_equal(ser, pser, 'describe')
 
 def test_reset_index(sers):
-	for ser, pser in sers.values():
-		ser = ser.sort_values()
-		pser = pser.sort_values()
-		assert_df_equal(ser, pser, 'reset_index')
-		assert_series_equal(ser, pser, 'reset_index', drop=True)
+    for ser, pser in sers.values():
+        ser = ser.sort_values()
+        pser = pser.sort_values()
+        assert_df_equal(ser, pser, 'reset_index')
+        assert_series_equal(ser, pser, 'reset_index', drop=True)
 
-	# Exceptions
-	ser3 = sers['ser3'][0]
-	assert pytest.raises(TypeError, ser3.reset_index, drop='foo')
+    # Exceptions
+    ser3 = sers['ser3'][0]
+    assert pytest.raises(TypeError, ser3.reset_index, drop='foo')
 
 def test_to_numpy(sers):
-	for ser, pser in sers.values():
-		assert isinstance(ser.to_numpy(), np.ndarray)
-		assert_array_equal(ser.to_numpy(), pser.to_numpy())
+    for ser, pser in sers.values():
+        assert isinstance(ser.to_numpy(), np.ndarray)
+        assert_array_equal(ser.to_numpy(), pser.to_numpy())


### PR DESCRIPTION
See #7 - I went ahead and did the PR.

To conform with PEP8, and for consistency with main code.

I removed some spaces at the ends of lines too.