### PR TITLE
Require pandas >= 0.24

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pandas >= 0.2
+pandas >= 0.24
 pytest == 4.6.3
 numpy


### PR DESCRIPTION
Before Pandas 0.24, there was no `pd.core.groupby.generic` module. This caused an exception to be raised in the following line: 

https://github.com/afraenkel/babypandas/blob/6d539b1935a6524db065e61426015dd438b0b9fb/babypandas/bpd.py#L1445