### PR TITLE
Hotfix/version workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -7,6 +7,9 @@ on:
       - closed
     branches:
       - master
+  push:
+    tags:
+      - '*'
 
 jobs:
   build-and-test:

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -31,7 +31,9 @@ jobs:
 
   build-and-publish:
     needs: build-and-test
-    if: github.event.pull_request.merged == true
+    if: >
+      (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'master') ||
+      (startsWith(github.ref, 'refs/tags/') && github.ref == 'refs/heads/master')
     name: Build and publish dists to PyPI
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-tests-on-push.yaml
+++ b/.github/workflows/run-tests-on-push.yaml
@@ -1,6 +1,8 @@
 name: Run Tests on Push
 on:
   push:
+    branches-ignore:
+      - master
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -90,4 +90,25 @@ Berkeley `datascience` module equivalents with `babypandas`:
 
 ## Development
 
-To publish changes to PyPI, simply push a tagged commit to the `master` branch of this repository. Note that the commit must be tagged!
+Publishing to PyPI requires that a tagged commit exists on the `master` branch. The GitHub Actions workflow will trigger
+package building and publishing to PyPI only when a commit on `master` is tagged. This can happen in one of two ways: 
+
+1. **Direct Tagged Commit to Master**: Commit your changes directly to `master` and tag the commit before pushing to 
+GitHub.
+```shell
+git commit -m "Your descriptive commit message"
+git tag <tag-name> # convention has been to tag with package version
+git push origin master
+git push origin <tag-name>
+```
+
+2. **Merge Pull Request to Master and Post-Hoc Tag**: Merge a pull request into `master`. After merging, tag the resulting 
+commit in `master`.
+```shell
+git checkout master
+git pull origin master
+git tag <tag-name>
+git push origin <tag-name>
+```
+
+Either of these approaches will trigger testing, building, and publishing of the package to PyPI.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md') as fh:
 setup(
     name = 'babypandas',
     packages = ['babypandas'],
-    version = '0.1.8',
+    version = '0.1.9',
     setup_requires=['pytest-runner'],
     install_requires = install_requires,
     tests_require = ['pytest'],


### PR DESCRIPTION
Increment babypandas version for re-push to pypi.

Ignoring master for run-tests-on-push action. 

Added conditional triggers for build-and-publish job to run ONLY WHEN:

1. a pull request is merged into `master`, this will run everything except the pypi push but is useful to verify that test and build is working. 
2. A new tag is pushed specifically to the `master` branch. This allows for post-hoc triggering of build and distribution.

**Once this is approved, please tag master with 0.1.9 (skipping 0.1.8) to trigger artifact distribution**.